### PR TITLE
doc(readme): clarify the purpose of this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-# Nautilus Enclaves
+# Nautilus SGX Service
 
-A collection of SGX enclaves utilized in products by Nautilus.
+A monorepo consisting of the Nautilus SGX RPC service as well the enclaves
+managed by it. This service manages the instantiation, scheduling, and
+dismantling of enclave instances used by the various products and services
+offered by Nautilus.  
+
+The [gRPC protocol][grpc] is utilized to expose enclave calls (ECALLs) to the various
+Nautilus applications.
+
+[grpc]: https://grpc.io/


### PR DESCRIPTION
This repository is intended to house the RPC service that makes enclave functionality available to more inexpensive hosts without SGX capabilities.