### PR TITLE
config: avoid Cargo conflicts with newer toolchains

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+# remove once teaclave has moved to Rust v1.68,
+# which stabilizes "sparse" protocol
+registries.crates-io.protocol = "git"
+
+# remove once teaclave has moved to Rust v1.69-nightly,
+# which introduced the "-Z terminal-urls" flag
+build.rustflags = ""
+
+# does not play well with sccache,
+# perhaps due to using a much different compiler version
+build.rustc-wrapper = ""


### PR DESCRIPTION
There are useful Cargo flags introduced in later versions of Rust than what we can use with Teaclave, and this commit overrides them for a peaceful co-existence.